### PR TITLE
Separate artifact creation from running tests, add manual CI runs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,15 +15,14 @@ on:
         type: string
       branch:
         description: Branch to build the plugin from
-        default: 'master'
+        default: 'main'
         required: false
         type: string
-      publish_artifact:
-        description: Set to 'true' if you want the resulted artifact to be published
-        default: false
+      artifact_name:
+        description: Set non-empty name for the built binary to be published with this artifact name
+        default: ~
         required: false
-        type: boolean
-
+        type: string
 
 jobs:
   build_plugin:
@@ -57,9 +56,9 @@ jobs:
         run: ctest --output-on-failure
         working-directory: '${{ inputs.build_dir }}'
       - name: Publish artifact
-        if: ${{ inputs.publish_artifact }}
+        if: ${{ inputs.artifact_name }}
         uses: actions/upload-artifact@v3
         with:
-          name: '${{ github.ref_name }}-artifact'
-          path: ./artifact_build/libica-plugin.so
+          name: ${{ inputs.artifact_name }}
+          path: ./${{ inputs.build_dir }}/libica-plugin.so
           if-no-files-found: error

--- a/.github/workflows/manual_artifact_run.yml
+++ b/.github/workflows/manual_artifact_run.yml
@@ -1,0 +1,35 @@
+name: Manual CI run
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_dir:
+        description: Directory where all the build output will be kept
+        default: 'build'
+        required: false
+        type: string
+      build_type:
+        description: CMake build type
+        default: 'RelWithDebInfo'
+        required: false
+        type: string
+      branch:
+        description: Branch to build the plugin from
+        default: 'main'
+        required: false
+        type: string
+      artifact_name:
+        description: Set non-empty name for the built binary to be published with this artifact name
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  run_ci:
+    name: Run CI
+    uses: tbricks/itiviti-cpp-analyzer/.github/workflows/build_and_test.yml@main
+    with:
+      build_dir: ${{ github.event.inputs.build_dir }}
+      build_type: ${{ github.event.inputs.build_type }}
+      branch: ${{ github.event.inputs.branch }}
+      artifact_name: ${{ github.event.inputs.artifact_name }}

--- a/.github/workflows/publish_artifact_from_main.yml
+++ b/.github/workflows/publish_artifact_from_main.yml
@@ -1,0 +1,16 @@
+name: Publish artifact on push to main
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build_artifact:
+    name: Prepare artifact
+    uses: tbricks/itiviti-cpp-analyzer/.github/workflows/build_and_test.yml@main
+    with:
+      build_type: 'RelWithDebInfo'
+      branch: ${{ github.ref_name }}
+      build_dir: artifact_build
+      artifact_name: ICA-artifact

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -1,6 +1,10 @@
 name: Run CI check on push
 
-on: push
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
 
 jobs:
   run_ci:
@@ -9,12 +13,3 @@ jobs:
     with:
       build_type: 'Debug'
       branch: ${{ github.ref_name }}
-  build_artifact:
-    name: Prepare artifact
-    needs: run_ci
-    uses: tbricks/itiviti-cpp-analyzer/.github/workflows/build_and_test.yml@main
-    with:
-      build_type: 'RelWithDebInfo'
-      branch: ${{ github.ref_name }}
-      build_dir: artifact_build
-      publish_artifact: true


### PR DESCRIPTION
We don't really need artifacts for each push on any branch, so let's divide it into two separate workflows: one runs tests on push to any branch except `main`, another one publishes built plugin when something is pushed to `main`.

In case you need an artifact for your branch, I've added a workflow that can be triggered manually