### PR TITLE
Parse multiple 'checks=...' entries

### DIFF
--- a/include/shared/common/Checks.h
+++ b/include/shared/common/Checks.h
@@ -80,7 +80,7 @@ class Checks
 
 public:
     Checks() = default;
-    Checks(const Checks & from);
+    Checks(const Checks & from) = default;
 
     explicit Checks(const std::string & checks)
     {
@@ -90,7 +90,6 @@ public:
     void clear()
     {
         m_checks.clear();
-        m_checks_str.clear();
         m_all = Check::Disabled;
     }
 
@@ -102,8 +101,7 @@ private:
     Check & get(std::string_view check) noexcept;
 
 private:
-    Check m_all;
-    std::string m_checks_str;
+    Check m_all = Check::Disabled;
     std::unordered_map<std::string_view, Check> m_checks;
 };
 

--- a/src/shared/common/Checks.cpp
+++ b/src/shared/common/Checks.cpp
@@ -69,7 +69,7 @@ class Parser
     static constexpr inline auto warning = Check::to_string(Check::Warning);
 
 public:
-    Parser(const std::string & checks_str)
+    Parser(std::string_view checks_str)
         : m_current_str(checks_str)
     { }
 
@@ -111,20 +111,6 @@ private:
 
 } // namespace parser
 
-
-Checks::Checks(const Checks & from)
-    : m_all(std::move(from.m_all))
-{
-    m_checks_str = from.m_checks_str;
-    const char * from_checks_str = from.m_checks_str.data();
-    const char * to_checks_str = m_checks_str.data();
-
-    for (const auto & [from_check, state] : from.m_checks) {
-        std::string_view to_check{from_check.data() - from_checks_str + to_checks_str, from_check.size()};
-        m_checks.try_emplace(to_check, state);
-    }
-}
-
 const Check Checks::operator [] (const std::string_view check) const noexcept
 {
     if (const auto it = m_checks.find(check); it != m_checks.end()) {
@@ -141,11 +127,8 @@ Check & Checks::get(const std::string_view check) noexcept
 
 std::optional<std::string> Checks::parse(const std::string_view checks_list)
 {
-    clear();
-    m_checks_str = checks_list;
-
     parser::Result result;
-    parser::Parser parser(m_checks_str);
+    parser::Parser parser(checks_list);
 
     while ((result = parser())) {
         const auto [check, state] = *result;


### PR DESCRIPTION
Previously, 'Checks' kept 'string', which was a copy of the one that's
given from the compiler by 'ParseArgs' call. Then an internal
'unordered_map<string_view, ...>' referred to it. Since I couldn't find
any modification of 'compilerInstance.getFrontendOpts().PluginArgs' in
the Clang sources, I believe, the map can refer to the strings given by
the compiler itself and remove copy of the plugin arguments. This is the
commit to suspect if arguments parsing blows up.

Since the map and the
string were cleaned at each 'Checks::parse' call, we could only keep
track of the last 'checks=...' argument. It was decided that we should
consider all the arguments of this form.

Resolves #3