### PR TITLE
Const param recursive member

### DIFF
--- a/test/do_dump.sh
+++ b/test/do_dump.sh
@@ -4,13 +4,13 @@ LLVM_ROOT="/opt/llvm-10"
 GCC_ROOT="/opt/gcc-8.2.0"
 FILTER="-ast-dump-filter=${2:-main}"
 
-${LLVM_ROOT}/bin/clang++ -MJ tmp.o.json --std=c++1z \
-    --gcc-toolchain=/opt/gcc-8.2.0 \
-    -isystem/opt/gcc-8.2.0/lib/gcc/x86_64-linux-gnu/8.2.0/include \
+clang++ -MJ tmp.o.json --std=c++1z \
     -o tmp.o -c $1
 
 sed -e '1s/^/[\n/' -e '$s/,$/\n]/' *.o.json > compile_commands.json
 
-${LLVM_ROOT}/bin/clang-check -extra-arg=-std=c++1z -ast-dump $FILTER $1
+clang-check -extra-arg=-std=c++1z -ast-dump $FILTER $1
+
+rm compile_commands.json tmp.o.json
 
 #${LLVM_ROOT}/bin/clang++ -Xclang -ast-dump -fsyntax-only --std=c++1z $1

--- a/test/do_test.sh
+++ b/test/do_test.sh
@@ -9,15 +9,15 @@ if [ -z "${CHECKS}" ]; then
 fi
 
 #    -fsyntax-only \
-${LLVM_ROOT}/bin/clang++ \
+clang++-10 \
     -Xclang -load -Xclang ../build/libica-plugin.so \
     -Xclang -add-plugin -Xclang ica-plugin \
     -Xclang -plugin-arg-ica-plugin -Xclang checks=${CHECKS} -Xclang -verify \
     -std=c++17 \
-    --gcc-toolchain=/opt/gcc-8.2.0 \
-    -isystem/opt/gcc-8.2.0/lib/gcc/x86_64-linux-gnu/8.2.0/include \
     -c \
     $1 -o $1.o
+
+rm $1.o
 
 #${LLVM_ROOT}/bin/clang++ \
 #    -Xclang -load -Xclang ../build/libclang-toy-plugin.so -Xclang -plugin -Xclang clang-toy-plugin \

--- a/test/internal/test_const_param_silence.cpp
+++ b/test/internal/test_const_param_silence.cpp
@@ -44,3 +44,17 @@ const int * add_const(int & i) // expected-warning {{'i' can have 'const' qualif
 
 int get_first(std::vector<int> & v) // expected-warning {{'v' can have 'const' qualifier}}
 { return v[0]; }
+
+struct Node
+{
+    void update(Node & parent) // no warning expected
+    {
+        if (parent.left != nullptr) {
+            parent.left->parent = &parent;
+        }
+    }
+
+    Node * left;
+    Node * right;
+    Node * parent;
+};

--- a/test/internal/test_improper_move.cpp
+++ b/test/internal/test_improper_move.cpp
@@ -70,8 +70,8 @@ auto try_move(T && value, int i)
 template <class... Args>
 void move_all(std::string * s, Args && ... args)
 {
-    std::move(s);               // clang-tidy: performance-move-const-arg
-    (..., (std::move(args)));   // expected-warning 1+ {{'args' got as non-const lvalue, moving from it may invalidate it's data}}
+    (void)std::move(s);               // clang-tidy: performance-move-const-arg
+    (..., ((void)std::move(args)));   // expected-warning 1+ {{'args' got as non-const lvalue, moving from it may invalidate it's data}}
 }
 
 void never_move_str(std::string && s) // expected-warning {{'s' is got as rvalue-reference, but never modified}}
@@ -90,7 +90,7 @@ struct StringPair
         second = std::move(rhs.second);
     }
 
-    StringPair(std::unique_ptr<StringPair> && ptr) // expected-warning {{'ptr' is got as rvalue-reference, but never modified}}
+    StringPair(std::unique_ptr<StringPair> && ptr) // no warning
     {
         first = std::move(ptr->first);
         second = std::move(ptr->second);


### PR DESCRIPTION
The thing in #8 was that there were 2 levels of member access (like `a.b->c`), so `extractDeclRef` couldn't find the initial expression (i.e. `a` in this example). Now `extractDeclRef` searches `DeclRefExpr` recursively

Resolves #8 